### PR TITLE
Feat markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ myEventHandler(event) {
 }
 ```
 
+### Render array of markers
+Markers can be bound to the element with the `markers` attribute like below:
+
+``` html
+<google-map markers.bind="myMarkers"></google-map>
+```
+
+This markers variable should be an array of objects with latitude and longitude key/value pairs:
+
+``` javascript
+var myMarkers = [
+	{
+        latitude: -27.451673,
+        longitude: 153.043981
+    },
+    {
+        latitude: 37.754582,
+        longitude: -122.446418
+    }
+];
+```
+
 ## Supported Properties
 
 - latitude: A latitude value for the map
@@ -77,6 +99,7 @@ myEventHandler(event) {
 - address: Provide an address that gets geocoded into latitude and longitude coordinates
 - zoom: A zoom value, default is 8
 - disableDefaultUI: A boolean of true or false. Default is false.
+- markers: An array of objects with `latitude` and `longitude` key/value pairs.
 
 ## Supported Events
 
@@ -89,3 +112,4 @@ This element still is missing some features, but they are in development.
 - Add in more configuration options
 - Work on making the custom element easier to extend
 - Work on supporting click events and events inside of the map, with callbacks support
+- Allow more marker options (color, label, etc.)

--- a/dist/amd/aurelia-google-maps.d.ts
+++ b/dist/amd/aurelia-google-maps.d.ts
@@ -2,6 +2,7 @@ declare module 'aurelia-google-maps' {
   import { inject }  from 'aurelia-dependency-injection';
   import { bindable, customElement }  from 'aurelia-templating';
   import { TaskQueue }  from 'aurelia-task-queue';
+  import { BindingEngine }  from 'aurelia-framework';
   export class Configure {
     constructor();
     options(obj: any): any;
@@ -14,9 +15,19 @@ declare module 'aurelia-google-maps' {
     latitude: any;
     zoom: any;
     disableDefaultUI: any;
+    markers: any;
     map: any;
-    constructor(element: any, taskQueue: any, config: any);
+    constructor(element: any, taskQueue: any, config: any, bindingEngine: any);
     attached(): any;
+    
+    /**
+         * Render a marker on the map and add it to collection of rendered markers
+         *
+         * @param latitude
+         * @param longitude
+         *
+         */
+    renderMarker(latitude: any, longitude: any): any;
     
     /**
          * Geocodes an address, once the Google Map script
@@ -56,6 +67,22 @@ declare module 'aurelia-google-maps' {
     latitudeChanged(newValue: any): any;
     longitudeChanged(newValue: any): any;
     zoomChanged(newValue: any): any;
+    
+    /**
+         * Observing changes in the entire markers object. This is critical in case the user sets marker to a new empty Array,
+         * where we need to resubscribe Observers and delete all previously rendered markers.
+         *
+         * @param newValue
+         */
+    markersChanged(newValue: any): any;
+    
+    /**
+         * Handle the change to the marker collection. Collection observer returns an array of splices which contains
+         * information about the change to the collection.
+         *
+         * @param splices
+         */
+    markerCollectionChange(splices: any): any;
     error(): any;
   }
 }

--- a/dist/amd/google-maps.js
+++ b/dist/amd/google-maps.js
@@ -1,4 +1,4 @@
-define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aurelia-task-queue', './configure'], function (exports, _aureliaDependencyInjection, _aureliaTemplating, _aureliaTaskQueue, _configure) {
+define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aurelia-task-queue', 'aurelia-framework', './configure'], function (exports, _aureliaDependencyInjection, _aureliaTemplating, _aureliaTaskQueue, _aureliaFramework, _configure) {
     'use strict';
 
     exports.__esModule = true;
@@ -47,9 +47,16 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
                 return false;
             },
             enumerable: true
+        }, {
+            key: 'markers',
+            decorators: [_aureliaTemplating.bindable],
+            initializer: function initializer() {
+                return [];
+            },
+            enumerable: true
         }], null, _instanceInitializers);
 
-        function GoogleMaps(element, taskQueue, config) {
+        function GoogleMaps(element, taskQueue, config, bindingEngine) {
             _classCallCheck(this, _GoogleMaps);
 
             _defineDecoratedPropertyDescriptor(this, 'address', _instanceInitializers);
@@ -62,12 +69,17 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
 
             _defineDecoratedPropertyDescriptor(this, 'disableDefaultUI', _instanceInitializers);
 
+            _defineDecoratedPropertyDescriptor(this, 'markers', _instanceInitializers);
+
             this.map = null;
+            this._renderedMarkers = [];
             this._scriptPromise = null;
+            this._markersSubscription = null;
 
             this.element = element;
             this.taskQueue = taskQueue;
             this.config = config;
+            this.bindingEngine = bindingEngine;
 
             if (!config.get('apiScript')) {
                 console.error('No API script is defined.');
@@ -112,24 +124,34 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
 
                     _this.element.dispatchEvent(changeEvent);
                 });
+            });
+        };
 
-                _this.createMarker({
-                    map: _this.map,
-                    position: latLng
+        GoogleMaps.prototype.renderMarker = function renderMarker(latitude, longitude) {
+            var _this2 = this;
+
+            var markerLatLng = new google.maps.LatLng(parseFloat(latitude), parseFloat(longitude));
+
+            this._scriptPromise.then(function () {
+                _this2.createMarker({
+                    map: _this2.map,
+                    position: markerLatLng
+                }).then(function (marker) {
+                    _this2._renderedMarkers.push(marker);
                 });
             });
         };
 
         GoogleMaps.prototype.geocodeAddress = function geocodeAddress(address, geocoder) {
-            var _this2 = this;
+            var _this3 = this;
 
             this._scriptPromise.then(function () {
                 geocoder.geocode({ 'address': address }, function (results, status) {
                     if (status === google.maps.GeocoderStatus.OK) {
-                        _this2.setCenter(results[0].geometry.location);
+                        _this3.setCenter(results[0].geometry.location);
 
-                        _this2.createMarker({
-                            map: _this2.map,
+                        _this3.createMarker({
+                            map: _this3.map,
                             position: results[0].geometry.location
                         });
                     }
@@ -150,7 +172,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         };
 
         GoogleMaps.prototype.loadApiScript = function loadApiScript() {
-            var _this3 = this;
+            var _this4 = this;
 
             if (this._scriptPromise) {
                 return this._scriptPromise;
@@ -163,10 +185,10 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
                     script.type = 'text/javascript';
                     script.async = true;
                     script.defer = true;
-                    script.src = _this3.config.get('apiScript') + '?key=' + _this3.config.get('apiKey') + '&callback=myGoogleMapsCallback';
+                    script.src = _this4.config.get('apiScript') + '?key=' + _this4.config.get('apiKey') + '&callback=myGoogleMapsCallback';
                     document.body.appendChild(script);
 
-                    _this3._scriptPromise = new Promise(function (resolve, reject) {
+                    _this4._scriptPromise = new Promise(function (resolve, reject) {
                         window.myGoogleMapsCallback = function () {
                             resolve();
                         };
@@ -177,7 +199,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
                     });
 
                     return {
-                        v: _this3._scriptPromise
+                        v: _this4._scriptPromise
                     };
                 })();
 
@@ -194,59 +216,49 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         };
 
         GoogleMaps.prototype.createMarker = function createMarker(options) {
-            this._scriptPromise.then(function () {
+            return this._scriptPromise.then(function () {
                 return Promise.resolve(new google.maps.Marker(options));
             });
         };
 
         GoogleMaps.prototype.getCenter = function getCenter() {
-            var _this4 = this;
+            var _this5 = this;
 
             this._scriptPromise.then(function () {
-                return Promise.resolve(_this4.map.getCenter());
+                return Promise.resolve(_this5.map.getCenter());
             });
         };
 
         GoogleMaps.prototype.setCenter = function setCenter(latLong) {
-            var _this5 = this;
+            var _this6 = this;
 
             this._scriptPromise.then(function () {
-                _this5.map.setCenter(latLong);
+                _this6.map.setCenter(latLong);
             });
         };
 
         GoogleMaps.prototype.updateCenter = function updateCenter() {
-            var _this6 = this;
+            var _this7 = this;
 
             this._scriptPromise.then(function () {
-                var latLng = new google.maps.LatLng(parseFloat(_this6.latitude), parseFloat(_this6.longitude));
-                _this6.setCenter(latLng);
+                var latLng = new google.maps.LatLng(parseFloat(_this7.latitude), parseFloat(_this7.longitude));
+                _this7.setCenter(latLng);
             });
         };
 
         GoogleMaps.prototype.addressChanged = function addressChanged(newValue) {
-            var _this7 = this;
+            var _this8 = this;
 
             this._scriptPromise.then(function () {
                 var geocoder = new google.maps.Geocoder();
 
-                _this7.taskQueue.queueMicroTask(function () {
-                    _this7.geocodeAddress(newValue, geocoder);
+                _this8.taskQueue.queueMicroTask(function () {
+                    _this8.geocodeAddress(newValue, geocoder);
                 });
             });
         };
 
         GoogleMaps.prototype.latitudeChanged = function latitudeChanged(newValue) {
-            var _this8 = this;
-
-            this._scriptPromise.then(function () {
-                _this8.taskQueue.queueMicroTask(function () {
-                    _this8.updateCenter();
-                });
-            });
-        };
-
-        GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
             var _this9 = this;
 
             this._scriptPromise.then(function () {
@@ -256,15 +268,128 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
             });
         };
 
-        GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
+        GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
             var _this10 = this;
 
             this._scriptPromise.then(function () {
                 _this10.taskQueue.queueMicroTask(function () {
-                    var zoomValue = parseInt(newValue, 10);
-                    _this10.map.setZoom(zoomValue);
+                    _this10.updateCenter();
                 });
             });
+        };
+
+        GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
+            var _this11 = this;
+
+            this._scriptPromise.then(function () {
+                _this11.taskQueue.queueMicroTask(function () {
+                    var zoomValue = parseInt(newValue, 10);
+                    _this11.map.setZoom(zoomValue);
+                });
+            });
+        };
+
+        GoogleMaps.prototype.markersChanged = function markersChanged(newValue) {
+            var _this12 = this;
+
+            if (null !== this._markersSubscription) {
+                this._markersSubscription.dispose();
+
+                for (var _iterator = this._renderedMarkers, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+                    var _ref;
+
+                    if (_isArray) {
+                        if (_i >= _iterator.length) break;
+                        _ref = _iterator[_i++];
+                    } else {
+                        _i = _iterator.next();
+                        if (_i.done) break;
+                        _ref = _i.value;
+                    }
+
+                    var marker = _ref;
+
+                    marker.setMap(null);
+                }
+
+                this._renderedMarkers = [];
+            }
+
+            this._markersSubscription = this.bindingEngine.collectionObserver(this.markers).subscribe(function (splices) {
+                _this12.markerCollectionChange(splices);
+            });
+
+            this._scriptPromise.then(function () {
+                for (var _iterator2 = newValue, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
+                    var _ref2;
+
+                    if (_isArray2) {
+                        if (_i2 >= _iterator2.length) break;
+                        _ref2 = _iterator2[_i2++];
+                    } else {
+                        _i2 = _iterator2.next();
+                        if (_i2.done) break;
+                        _ref2 = _i2.value;
+                    }
+
+                    var marker = _ref2;
+
+                    _this12.renderMarker(marker.latitude, marker.longitude);
+                }
+            });
+        };
+
+        GoogleMaps.prototype.markerCollectionChange = function markerCollectionChange(splices) {
+            for (var _iterator3 = splices, _isArray3 = Array.isArray(_iterator3), _i3 = 0, _iterator3 = _isArray3 ? _iterator3 : _iterator3[Symbol.iterator]();;) {
+                var _ref3;
+
+                if (_isArray3) {
+                    if (_i3 >= _iterator3.length) break;
+                    _ref3 = _iterator3[_i3++];
+                } else {
+                    _i3 = _iterator3.next();
+                    if (_i3.done) break;
+                    _ref3 = _i3.value;
+                }
+
+                var splice = _ref3;
+
+                if (splice.removed.length) {
+                    for (var _iterator4 = splice.removed, _isArray4 = Array.isArray(_iterator4), _i4 = 0, _iterator4 = _isArray4 ? _iterator4 : _iterator4[Symbol.iterator]();;) {
+                        var _ref4;
+
+                        if (_isArray4) {
+                            if (_i4 >= _iterator4.length) break;
+                            _ref4 = _iterator4[_i4++];
+                        } else {
+                            _i4 = _iterator4.next();
+                            if (_i4.done) break;
+                            _ref4 = _i4.value;
+                        }
+
+                        var removedObj = _ref4;
+
+                        for (var markerIndex in this._renderedMarkers) {
+                            if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
+                                var renderedMarker = this._renderedMarkers[markerIndex];
+
+                                if (renderedMarker.position.lat() == removedObj.latitude && renderedMarker.position.lng() == removedObj.longitude) {
+                                    renderedMarker.setMap(null);
+
+                                    this._renderedMarkers.splice(markerIndex, 1);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (splice.addedCount) {
+                    var addedMarker = this.markers[splice.index];
+
+                    this.renderMarker(addedMarker.latitude, addedMarker.longitude);
+                }
+            }
         };
 
         GoogleMaps.prototype.error = function error() {
@@ -272,7 +397,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         };
 
         var _GoogleMaps = GoogleMaps;
-        GoogleMaps = _aureliaDependencyInjection.inject(Element, _aureliaTaskQueue.TaskQueue, _configure.Configure)(GoogleMaps) || GoogleMaps;
+        GoogleMaps = _aureliaDependencyInjection.inject(Element, _aureliaTaskQueue.TaskQueue, _configure.Configure, _aureliaFramework.BindingEngine)(GoogleMaps) || GoogleMaps;
         GoogleMaps = _aureliaTemplating.customElement('google-map')(GoogleMaps) || GoogleMaps;
         return GoogleMaps;
     })();

--- a/dist/aurelia-google-maps.d.ts
+++ b/dist/aurelia-google-maps.d.ts
@@ -2,6 +2,7 @@ declare module 'aurelia-google-maps' {
   import { inject }  from 'aurelia-dependency-injection';
   import { bindable, customElement }  from 'aurelia-templating';
   import { TaskQueue }  from 'aurelia-task-queue';
+  import { BindingEngine }  from 'aurelia-framework';
   export class Configure {
     constructor();
     options(obj: any): any;
@@ -14,9 +15,19 @@ declare module 'aurelia-google-maps' {
     latitude: any;
     zoom: any;
     disableDefaultUI: any;
+    markers: any;
     map: any;
-    constructor(element: any, taskQueue: any, config: any);
+    constructor(element: any, taskQueue: any, config: any, bindingEngine: any);
     attached(): any;
+    
+    /**
+         * Render a marker on the map and add it to collection of rendered markers
+         *
+         * @param latitude
+         * @param longitude
+         *
+         */
+    renderMarker(latitude: any, longitude: any): any;
     
     /**
          * Geocodes an address, once the Google Map script
@@ -56,6 +67,22 @@ declare module 'aurelia-google-maps' {
     latitudeChanged(newValue: any): any;
     longitudeChanged(newValue: any): any;
     zoomChanged(newValue: any): any;
+    
+    /**
+         * Observing changes in the entire markers object. This is critical in case the user sets marker to a new empty Array,
+         * where we need to resubscribe Observers and delete all previously rendered markers.
+         *
+         * @param newValue
+         */
+    markersChanged(newValue: any): any;
+    
+    /**
+         * Handle the change to the marker collection. Collection observer returns an array of splices which contains
+         * information about the change to the collection.
+         *
+         * @param splices
+         */
+    markerCollectionChange(splices: any): any;
     error(): any;
   }
 }

--- a/dist/aurelia-google-maps.js
+++ b/dist/aurelia-google-maps.js
@@ -1,6 +1,7 @@
 import {inject} from 'aurelia-dependency-injection';
 import {bindable,customElement} from 'aurelia-templating';
 import {TaskQueue} from 'aurelia-task-queue';
+import {BindingEngine} from 'aurelia-framework';
 
 export class Configure {
 
@@ -26,21 +27,25 @@ export class Configure {
 }
 
 @customElement('google-map')
-@inject(Element, TaskQueue, Configure)
+@inject(Element, TaskQueue, Configure, BindingEngine)
 export class GoogleMaps {
     @bindable address = null;
     @bindable longitude = 0;
     @bindable latitude = 0;
     @bindable zoom = 8;
     @bindable disableDefaultUI = false;
+    @bindable markers = [];
 
     map = null;
+    _renderedMarkers = [];
     _scriptPromise = null;
+    _markersSubscription = null;
 
-    constructor(element, taskQueue, config) {
+    constructor(element, taskQueue, config, bindingEngine) {
         this.element = element;
         this.taskQueue = taskQueue;
         this.config = config;
+        this.bindingEngine = bindingEngine;
 
         if (!config.get('apiScript')) {
             console.error('No API script is defined.');
@@ -69,6 +74,7 @@ export class GoogleMaps {
 
             this.map = new google.maps.Map(this.element, options);
 
+            // Add event listener for click event
             this.map.addListener('click', (e) => {
                 let changeEvent;
                 if (window.CustomEvent) {
@@ -83,10 +89,27 @@ export class GoogleMaps {
 
                 this.element.dispatchEvent(changeEvent);
             });
+        });
+    }
 
+    /**
+     * Render a marker on the map and add it to collection of rendered markers
+     *
+     * @param latitude
+     * @param longitude
+     *
+     */
+    renderMarker(latitude, longitude) {
+        let markerLatLng = new google.maps.LatLng(parseFloat(latitude), parseFloat(longitude));
+
+        this._scriptPromise.then(() => {
+            // Create the marker
             this.createMarker({
                 map: this.map,
-                position: latLng
+                position: markerLatLng
+            }).then(marker => {
+                // Add it the array of rendered markers
+                this._renderedMarkers.push(marker);
             });
         });
     }
@@ -175,7 +198,7 @@ export class GoogleMaps {
     }
 
     createMarker(options) {
-        this._scriptPromise.then(() => {
+        return this._scriptPromise.then(() => {
             return Promise.resolve(new google.maps.Marker(options));
         });
     }
@@ -232,6 +255,84 @@ export class GoogleMaps {
                 this.map.setZoom(zoomValue);
             });
         });
+    }
+
+    /**
+     * Observing changes in the entire markers object. This is critical in case the user sets marker to a new empty Array,
+     * where we need to resubscribe Observers and delete all previously rendered markers.
+     *
+     * @param newValue
+     */
+    markersChanged(newValue) {
+        // If there was a previous subscription
+        if (null !== this._markersSubscription) {
+            // Dispose of the subscription
+            this._markersSubscription.dispose();
+
+            // Remove all the currently rendered markers
+            for (let marker of this._renderedMarkers) {
+                marker.setMap(null);
+            }
+
+            // And empty the renderMarkers collection
+            this._renderedMarkers = [];
+        }
+
+        // Add the subcription to markers
+        this._markersSubscription = this.bindingEngine
+            .collectionObserver(this.markers)
+            .subscribe((splices) => { this.markerCollectionChange(splices) })
+        ;
+
+        // Render all markers again
+        this._scriptPromise.then(() => {
+            for (let marker of newValue) {
+                this.renderMarker(marker.latitude, marker.longitude);
+            }
+        });
+    }
+
+    /**
+     * Handle the change to the marker collection. Collection observer returns an array of splices which contains
+     * information about the change to the collection.
+     *
+     * @param splices
+     */
+    markerCollectionChange(splices) {
+        for (let splice of splices) {
+            if (splice.removed.length) {
+
+                // Iterate over all the removed markers
+                for (let removedObj of splice.removed) {
+
+                    // Iterate over all the rendered markers to find the one to remove
+                    for (let markerIndex in this._renderedMarkers){
+                        if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
+                            var renderedMarker = this._renderedMarkers[markerIndex];
+
+                            // Check if the latitude/longitude matches
+                            if (renderedMarker.position.lat() == removedObj.latitude &&
+                                renderedMarker.position.lng() == removedObj.longitude) {
+
+                                // Set the map to null;
+                                renderedMarker.setMap(null);
+
+                                // Splice out this rendered marker as well
+                                this._renderedMarkers.splice(markerIndex, 1);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Add the new markers to the map
+            if (splice.addedCount) {
+                let addedMarker = this.markers[splice.index];
+
+                this.renderMarker(addedMarker.latitude, addedMarker.longitude);
+            }
+        }
     }
 
     error() {

--- a/dist/commonjs/aurelia-google-maps.d.ts
+++ b/dist/commonjs/aurelia-google-maps.d.ts
@@ -2,6 +2,7 @@ declare module 'aurelia-google-maps' {
   import { inject }  from 'aurelia-dependency-injection';
   import { bindable, customElement }  from 'aurelia-templating';
   import { TaskQueue }  from 'aurelia-task-queue';
+  import { BindingEngine }  from 'aurelia-framework';
   export class Configure {
     constructor();
     options(obj: any): any;
@@ -14,9 +15,19 @@ declare module 'aurelia-google-maps' {
     latitude: any;
     zoom: any;
     disableDefaultUI: any;
+    markers: any;
     map: any;
-    constructor(element: any, taskQueue: any, config: any);
+    constructor(element: any, taskQueue: any, config: any, bindingEngine: any);
     attached(): any;
+    
+    /**
+         * Render a marker on the map and add it to collection of rendered markers
+         *
+         * @param latitude
+         * @param longitude
+         *
+         */
+    renderMarker(latitude: any, longitude: any): any;
     
     /**
          * Geocodes an address, once the Google Map script
@@ -56,6 +67,22 @@ declare module 'aurelia-google-maps' {
     latitudeChanged(newValue: any): any;
     longitudeChanged(newValue: any): any;
     zoomChanged(newValue: any): any;
+    
+    /**
+         * Observing changes in the entire markers object. This is critical in case the user sets marker to a new empty Array,
+         * where we need to resubscribe Observers and delete all previously rendered markers.
+         *
+         * @param newValue
+         */
+    markersChanged(newValue: any): any;
+    
+    /**
+         * Handle the change to the marker collection. Collection observer returns an array of splices which contains
+         * information about the change to the collection.
+         *
+         * @param splices
+         */
+    markerCollectionChange(splices: any): any;
     error(): any;
   }
 }

--- a/dist/commonjs/google-maps.js
+++ b/dist/commonjs/google-maps.js
@@ -14,6 +14,8 @@ var _aureliaTemplating = require('aurelia-templating');
 
 var _aureliaTaskQueue = require('aurelia-task-queue');
 
+var _aureliaFramework = require('aurelia-framework');
+
 var _configure = require('./configure');
 
 var GoogleMaps = (function () {
@@ -54,9 +56,16 @@ var GoogleMaps = (function () {
             return false;
         },
         enumerable: true
+    }, {
+        key: 'markers',
+        decorators: [_aureliaTemplating.bindable],
+        initializer: function initializer() {
+            return [];
+        },
+        enumerable: true
     }], null, _instanceInitializers);
 
-    function GoogleMaps(element, taskQueue, config) {
+    function GoogleMaps(element, taskQueue, config, bindingEngine) {
         _classCallCheck(this, _GoogleMaps);
 
         _defineDecoratedPropertyDescriptor(this, 'address', _instanceInitializers);
@@ -69,12 +78,17 @@ var GoogleMaps = (function () {
 
         _defineDecoratedPropertyDescriptor(this, 'disableDefaultUI', _instanceInitializers);
 
+        _defineDecoratedPropertyDescriptor(this, 'markers', _instanceInitializers);
+
         this.map = null;
+        this._renderedMarkers = [];
         this._scriptPromise = null;
+        this._markersSubscription = null;
 
         this.element = element;
         this.taskQueue = taskQueue;
         this.config = config;
+        this.bindingEngine = bindingEngine;
 
         if (!config.get('apiScript')) {
             console.error('No API script is defined.');
@@ -119,24 +133,34 @@ var GoogleMaps = (function () {
 
                 _this.element.dispatchEvent(changeEvent);
             });
+        });
+    };
 
-            _this.createMarker({
-                map: _this.map,
-                position: latLng
+    GoogleMaps.prototype.renderMarker = function renderMarker(latitude, longitude) {
+        var _this2 = this;
+
+        var markerLatLng = new google.maps.LatLng(parseFloat(latitude), parseFloat(longitude));
+
+        this._scriptPromise.then(function () {
+            _this2.createMarker({
+                map: _this2.map,
+                position: markerLatLng
+            }).then(function (marker) {
+                _this2._renderedMarkers.push(marker);
             });
         });
     };
 
     GoogleMaps.prototype.geocodeAddress = function geocodeAddress(address, geocoder) {
-        var _this2 = this;
+        var _this3 = this;
 
         this._scriptPromise.then(function () {
             geocoder.geocode({ 'address': address }, function (results, status) {
                 if (status === google.maps.GeocoderStatus.OK) {
-                    _this2.setCenter(results[0].geometry.location);
+                    _this3.setCenter(results[0].geometry.location);
 
-                    _this2.createMarker({
-                        map: _this2.map,
+                    _this3.createMarker({
+                        map: _this3.map,
                         position: results[0].geometry.location
                     });
                 }
@@ -157,7 +181,7 @@ var GoogleMaps = (function () {
     };
 
     GoogleMaps.prototype.loadApiScript = function loadApiScript() {
-        var _this3 = this;
+        var _this4 = this;
 
         if (this._scriptPromise) {
             return this._scriptPromise;
@@ -170,10 +194,10 @@ var GoogleMaps = (function () {
                 script.type = 'text/javascript';
                 script.async = true;
                 script.defer = true;
-                script.src = _this3.config.get('apiScript') + '?key=' + _this3.config.get('apiKey') + '&callback=myGoogleMapsCallback';
+                script.src = _this4.config.get('apiScript') + '?key=' + _this4.config.get('apiKey') + '&callback=myGoogleMapsCallback';
                 document.body.appendChild(script);
 
-                _this3._scriptPromise = new Promise(function (resolve, reject) {
+                _this4._scriptPromise = new Promise(function (resolve, reject) {
                     window.myGoogleMapsCallback = function () {
                         resolve();
                     };
@@ -184,7 +208,7 @@ var GoogleMaps = (function () {
                 });
 
                 return {
-                    v: _this3._scriptPromise
+                    v: _this4._scriptPromise
                 };
             })();
 
@@ -201,59 +225,49 @@ var GoogleMaps = (function () {
     };
 
     GoogleMaps.prototype.createMarker = function createMarker(options) {
-        this._scriptPromise.then(function () {
+        return this._scriptPromise.then(function () {
             return Promise.resolve(new google.maps.Marker(options));
         });
     };
 
     GoogleMaps.prototype.getCenter = function getCenter() {
-        var _this4 = this;
+        var _this5 = this;
 
         this._scriptPromise.then(function () {
-            return Promise.resolve(_this4.map.getCenter());
+            return Promise.resolve(_this5.map.getCenter());
         });
     };
 
     GoogleMaps.prototype.setCenter = function setCenter(latLong) {
-        var _this5 = this;
+        var _this6 = this;
 
         this._scriptPromise.then(function () {
-            _this5.map.setCenter(latLong);
+            _this6.map.setCenter(latLong);
         });
     };
 
     GoogleMaps.prototype.updateCenter = function updateCenter() {
-        var _this6 = this;
+        var _this7 = this;
 
         this._scriptPromise.then(function () {
-            var latLng = new google.maps.LatLng(parseFloat(_this6.latitude), parseFloat(_this6.longitude));
-            _this6.setCenter(latLng);
+            var latLng = new google.maps.LatLng(parseFloat(_this7.latitude), parseFloat(_this7.longitude));
+            _this7.setCenter(latLng);
         });
     };
 
     GoogleMaps.prototype.addressChanged = function addressChanged(newValue) {
-        var _this7 = this;
+        var _this8 = this;
 
         this._scriptPromise.then(function () {
             var geocoder = new google.maps.Geocoder();
 
-            _this7.taskQueue.queueMicroTask(function () {
-                _this7.geocodeAddress(newValue, geocoder);
+            _this8.taskQueue.queueMicroTask(function () {
+                _this8.geocodeAddress(newValue, geocoder);
             });
         });
     };
 
     GoogleMaps.prototype.latitudeChanged = function latitudeChanged(newValue) {
-        var _this8 = this;
-
-        this._scriptPromise.then(function () {
-            _this8.taskQueue.queueMicroTask(function () {
-                _this8.updateCenter();
-            });
-        });
-    };
-
-    GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
         var _this9 = this;
 
         this._scriptPromise.then(function () {
@@ -263,15 +277,128 @@ var GoogleMaps = (function () {
         });
     };
 
-    GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
+    GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
         var _this10 = this;
 
         this._scriptPromise.then(function () {
             _this10.taskQueue.queueMicroTask(function () {
-                var zoomValue = parseInt(newValue, 10);
-                _this10.map.setZoom(zoomValue);
+                _this10.updateCenter();
             });
         });
+    };
+
+    GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
+        var _this11 = this;
+
+        this._scriptPromise.then(function () {
+            _this11.taskQueue.queueMicroTask(function () {
+                var zoomValue = parseInt(newValue, 10);
+                _this11.map.setZoom(zoomValue);
+            });
+        });
+    };
+
+    GoogleMaps.prototype.markersChanged = function markersChanged(newValue) {
+        var _this12 = this;
+
+        if (null !== this._markersSubscription) {
+            this._markersSubscription.dispose();
+
+            for (var _iterator = this._renderedMarkers, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+                var _ref;
+
+                if (_isArray) {
+                    if (_i >= _iterator.length) break;
+                    _ref = _iterator[_i++];
+                } else {
+                    _i = _iterator.next();
+                    if (_i.done) break;
+                    _ref = _i.value;
+                }
+
+                var marker = _ref;
+
+                marker.setMap(null);
+            }
+
+            this._renderedMarkers = [];
+        }
+
+        this._markersSubscription = this.bindingEngine.collectionObserver(this.markers).subscribe(function (splices) {
+            _this12.markerCollectionChange(splices);
+        });
+
+        this._scriptPromise.then(function () {
+            for (var _iterator2 = newValue, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
+                var _ref2;
+
+                if (_isArray2) {
+                    if (_i2 >= _iterator2.length) break;
+                    _ref2 = _iterator2[_i2++];
+                } else {
+                    _i2 = _iterator2.next();
+                    if (_i2.done) break;
+                    _ref2 = _i2.value;
+                }
+
+                var marker = _ref2;
+
+                _this12.renderMarker(marker.latitude, marker.longitude);
+            }
+        });
+    };
+
+    GoogleMaps.prototype.markerCollectionChange = function markerCollectionChange(splices) {
+        for (var _iterator3 = splices, _isArray3 = Array.isArray(_iterator3), _i3 = 0, _iterator3 = _isArray3 ? _iterator3 : _iterator3[Symbol.iterator]();;) {
+            var _ref3;
+
+            if (_isArray3) {
+                if (_i3 >= _iterator3.length) break;
+                _ref3 = _iterator3[_i3++];
+            } else {
+                _i3 = _iterator3.next();
+                if (_i3.done) break;
+                _ref3 = _i3.value;
+            }
+
+            var splice = _ref3;
+
+            if (splice.removed.length) {
+                for (var _iterator4 = splice.removed, _isArray4 = Array.isArray(_iterator4), _i4 = 0, _iterator4 = _isArray4 ? _iterator4 : _iterator4[Symbol.iterator]();;) {
+                    var _ref4;
+
+                    if (_isArray4) {
+                        if (_i4 >= _iterator4.length) break;
+                        _ref4 = _iterator4[_i4++];
+                    } else {
+                        _i4 = _iterator4.next();
+                        if (_i4.done) break;
+                        _ref4 = _i4.value;
+                    }
+
+                    var removedObj = _ref4;
+
+                    for (var markerIndex in this._renderedMarkers) {
+                        if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
+                            var renderedMarker = this._renderedMarkers[markerIndex];
+
+                            if (renderedMarker.position.lat() == removedObj.latitude && renderedMarker.position.lng() == removedObj.longitude) {
+                                renderedMarker.setMap(null);
+
+                                this._renderedMarkers.splice(markerIndex, 1);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (splice.addedCount) {
+                var addedMarker = this.markers[splice.index];
+
+                this.renderMarker(addedMarker.latitude, addedMarker.longitude);
+            }
+        }
     };
 
     GoogleMaps.prototype.error = function error() {
@@ -279,7 +406,7 @@ var GoogleMaps = (function () {
     };
 
     var _GoogleMaps = GoogleMaps;
-    GoogleMaps = _aureliaDependencyInjection.inject(Element, _aureliaTaskQueue.TaskQueue, _configure.Configure)(GoogleMaps) || GoogleMaps;
+    GoogleMaps = _aureliaDependencyInjection.inject(Element, _aureliaTaskQueue.TaskQueue, _configure.Configure, _aureliaFramework.BindingEngine)(GoogleMaps) || GoogleMaps;
     GoogleMaps = _aureliaTemplating.customElement('google-map')(GoogleMaps) || GoogleMaps;
     return GoogleMaps;
 })();

--- a/dist/es6/aurelia-google-maps.d.ts
+++ b/dist/es6/aurelia-google-maps.d.ts
@@ -2,6 +2,7 @@ declare module 'aurelia-google-maps' {
   import { inject }  from 'aurelia-dependency-injection';
   import { bindable, customElement }  from 'aurelia-templating';
   import { TaskQueue }  from 'aurelia-task-queue';
+  import { BindingEngine }  from 'aurelia-framework';
   export class Configure {
     constructor();
     options(obj: any): any;
@@ -14,9 +15,19 @@ declare module 'aurelia-google-maps' {
     latitude: any;
     zoom: any;
     disableDefaultUI: any;
+    markers: any;
     map: any;
-    constructor(element: any, taskQueue: any, config: any);
+    constructor(element: any, taskQueue: any, config: any, bindingEngine: any);
     attached(): any;
+    
+    /**
+         * Render a marker on the map and add it to collection of rendered markers
+         *
+         * @param latitude
+         * @param longitude
+         *
+         */
+    renderMarker(latitude: any, longitude: any): any;
     
     /**
          * Geocodes an address, once the Google Map script
@@ -56,6 +67,22 @@ declare module 'aurelia-google-maps' {
     latitudeChanged(newValue: any): any;
     longitudeChanged(newValue: any): any;
     zoomChanged(newValue: any): any;
+    
+    /**
+         * Observing changes in the entire markers object. This is critical in case the user sets marker to a new empty Array,
+         * where we need to resubscribe Observers and delete all previously rendered markers.
+         *
+         * @param newValue
+         */
+    markersChanged(newValue: any): any;
+    
+    /**
+         * Handle the change to the marker collection. Collection observer returns an array of splices which contains
+         * information about the change to the collection.
+         *
+         * @param splices
+         */
+    markerCollectionChange(splices: any): any;
     error(): any;
   }
 }

--- a/dist/system/aurelia-google-maps.d.ts
+++ b/dist/system/aurelia-google-maps.d.ts
@@ -2,6 +2,7 @@ declare module 'aurelia-google-maps' {
   import { inject }  from 'aurelia-dependency-injection';
   import { bindable, customElement }  from 'aurelia-templating';
   import { TaskQueue }  from 'aurelia-task-queue';
+  import { BindingEngine }  from 'aurelia-framework';
   export class Configure {
     constructor();
     options(obj: any): any;
@@ -14,9 +15,19 @@ declare module 'aurelia-google-maps' {
     latitude: any;
     zoom: any;
     disableDefaultUI: any;
+    markers: any;
     map: any;
-    constructor(element: any, taskQueue: any, config: any);
+    constructor(element: any, taskQueue: any, config: any, bindingEngine: any);
     attached(): any;
+    
+    /**
+         * Render a marker on the map and add it to collection of rendered markers
+         *
+         * @param latitude
+         * @param longitude
+         *
+         */
+    renderMarker(latitude: any, longitude: any): any;
     
     /**
          * Geocodes an address, once the Google Map script
@@ -56,6 +67,22 @@ declare module 'aurelia-google-maps' {
     latitudeChanged(newValue: any): any;
     longitudeChanged(newValue: any): any;
     zoomChanged(newValue: any): any;
+    
+    /**
+         * Observing changes in the entire markers object. This is critical in case the user sets marker to a new empty Array,
+         * where we need to resubscribe Observers and delete all previously rendered markers.
+         *
+         * @param newValue
+         */
+    markersChanged(newValue: any): any;
+    
+    /**
+         * Handle the change to the marker collection. Collection observer returns an array of splices which contains
+         * information about the change to the collection.
+         *
+         * @param splices
+         */
+    markerCollectionChange(splices: any): any;
     error(): any;
   }
 }


### PR DESCRIPTION
I've added in markers and seems to be working alright. The method of checking for deleted markers sucks at the moment but it does work. Not sure what would be a better approach though.

Would be good to be able to add in some more marker options (color, labels etc.), but I don't think I'll be requiring it just yet so I probably won't be in any hurry to add it yet.

We implemented the geocoder as an Aurelia service within our app too, not sure if it would make sense to have a service like that within the scope of this plugin, or another, but geocoding an address before creating a marker seems likes a somewhat common use case (at least for us).

One important thing that I had removed was that when latitude and longitude were bound, the attached method would usually have created a map marker, however the functionality here got confusing when you specified your own marker array but wanted to orient the map somewhere on load (again, another use case that we've had).
