### PR TITLE
fix(promises): use mapPromises wherever possible

### DIFF
--- a/dist/amd/google-maps.js
+++ b/dist/amd/google-maps.js
@@ -172,7 +172,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
 
             var markerLatLng = new google.maps.LatLng(parseFloat(marker.latitude), parseFloat(marker.longitude));
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 _this2.createMarker({
                     map: _this2.map,
                     position: markerLatLng
@@ -218,7 +218,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         GoogleMaps.prototype.geocodeAddress = function geocodeAddress(address, geocoder) {
             var _this3 = this;
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 geocoder.geocode({ 'address': address }, function (results, status) {
                     if (status === google.maps.GeocoderStatus.OK) {
                         _this3.setCenter(results[0].geometry.location);
@@ -303,7 +303,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         GoogleMaps.prototype.getCenter = function getCenter() {
             var _this5 = this;
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 return Promise.resolve(_this5.map.getCenter());
             });
         };
@@ -328,7 +328,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         GoogleMaps.prototype.addressChanged = function addressChanged(newValue) {
             var _this8 = this;
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 var geocoder = new google.maps.Geocoder();
 
                 _this8.taskQueue.queueMicroTask(function () {
@@ -340,7 +340,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         GoogleMaps.prototype.latitudeChanged = function latitudeChanged(newValue) {
             var _this9 = this;
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 _this9.taskQueue.queueMicroTask(function () {
                     _this9.updateCenter();
                 });
@@ -350,7 +350,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
             var _this10 = this;
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 _this10.taskQueue.queueMicroTask(function () {
                     _this10.updateCenter();
                 });
@@ -360,7 +360,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
         GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
             var _this11 = this;
 
-            this._scriptPromise.then(function () {
+            this._mapPromise.then(function () {
                 _this11.taskQueue.queueMicroTask(function () {
                     var zoomValue = parseInt(newValue, 10);
                     _this11.map.setZoom(zoomValue);

--- a/dist/aurelia-google-maps.js
+++ b/dist/aurelia-google-maps.js
@@ -148,7 +148,7 @@ export class GoogleMaps {
     renderMarker(marker) {
         let markerLatLng = new google.maps.LatLng(parseFloat(marker.latitude), parseFloat(marker.longitude));
 
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             // Create the marker
             this.createMarker({
                 map: this.map,
@@ -206,7 +206,7 @@ export class GoogleMaps {
      *
      */
     geocodeAddress(address, geocoder) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             geocoder.geocode({'address': address}, (results, status) => {
                 if (status === google.maps.GeocoderStatus.OK) {
                     this.setCenter(results[0].geometry.location);
@@ -293,7 +293,7 @@ export class GoogleMaps {
     }
 
     getCenter() {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             return Promise.resolve(this.map.getCenter());
         });
     }
@@ -312,7 +312,7 @@ export class GoogleMaps {
     }
 
     addressChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             let geocoder = new google.maps.Geocoder;
 
             this.taskQueue.queueMicroTask(() => {
@@ -322,7 +322,7 @@ export class GoogleMaps {
     }
 
     latitudeChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 this.updateCenter();
             });
@@ -330,7 +330,7 @@ export class GoogleMaps {
     }
 
     longitudeChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 this.updateCenter();
             });
@@ -338,12 +338,12 @@ export class GoogleMaps {
     }
 
     zoomChanged(newValue) {
-        this._scriptPromise.then(() => {
-            this.taskQueue.queueMicroTask(() => {
-                let zoomValue = parseInt(newValue, 10);
-                this.map.setZoom(zoomValue);
+        this._mapPromise.then(() => {
+                this.taskQueue.queueMicroTask(() => {
+                    let zoomValue = parseInt(newValue, 10);
+                    this.map.setZoom(zoomValue);
+                });
             });
-        });
     }
 
     /**

--- a/dist/commonjs/google-maps.js
+++ b/dist/commonjs/google-maps.js
@@ -175,7 +175,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
 
         var markerLatLng = new google.maps.LatLng(parseFloat(marker.latitude), parseFloat(marker.longitude));
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             _this2.createMarker({
                 map: _this2.map,
                 position: markerLatLng
@@ -221,7 +221,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
     GoogleMaps.prototype.geocodeAddress = function geocodeAddress(address, geocoder) {
         var _this3 = this;
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             geocoder.geocode({ 'address': address }, function (results, status) {
                 if (status === google.maps.GeocoderStatus.OK) {
                     _this3.setCenter(results[0].geometry.location);
@@ -306,7 +306,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
     GoogleMaps.prototype.getCenter = function getCenter() {
         var _this5 = this;
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             return Promise.resolve(_this5.map.getCenter());
         });
     };
@@ -331,7 +331,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
     GoogleMaps.prototype.addressChanged = function addressChanged(newValue) {
         var _this8 = this;
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             var geocoder = new google.maps.Geocoder();
 
             _this8.taskQueue.queueMicroTask(function () {
@@ -343,7 +343,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
     GoogleMaps.prototype.latitudeChanged = function latitudeChanged(newValue) {
         var _this9 = this;
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             _this9.taskQueue.queueMicroTask(function () {
                 _this9.updateCenter();
             });
@@ -353,7 +353,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
     GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
         var _this10 = this;
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             _this10.taskQueue.queueMicroTask(function () {
                 _this10.updateCenter();
             });
@@ -363,7 +363,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
     GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
         var _this11 = this;
 
-        this._scriptPromise.then(function () {
+        this._mapPromise.then(function () {
             _this11.taskQueue.queueMicroTask(function () {
                 var zoomValue = parseInt(newValue, 10);
                 _this11.map.setZoom(zoomValue);

--- a/dist/es2015/google-maps.js
+++ b/dist/es2015/google-maps.js
@@ -155,7 +155,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     renderMarker(marker) {
         let markerLatLng = new google.maps.LatLng(parseFloat(marker.latitude), parseFloat(marker.longitude));
 
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.createMarker({
                 map: this.map,
                 position: markerLatLng
@@ -199,7 +199,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     }
 
     geocodeAddress(address, geocoder) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             geocoder.geocode({ 'address': address }, (results, status) => {
                 if (status === google.maps.GeocoderStatus.OK) {
                     this.setCenter(results[0].geometry.location);
@@ -270,7 +270,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     }
 
     getCenter() {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             return Promise.resolve(this.map.getCenter());
         });
     }
@@ -289,7 +289,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     }
 
     addressChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             let geocoder = new google.maps.Geocoder();
 
             this.taskQueue.queueMicroTask(() => {
@@ -299,7 +299,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     }
 
     latitudeChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 this.updateCenter();
             });
@@ -307,7 +307,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     }
 
     longitudeChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 this.updateCenter();
             });
@@ -315,7 +315,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
     }
 
     zoomChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 let zoomValue = parseInt(newValue, 10);
                 this.map.setZoom(zoomValue);

--- a/dist/system/google-maps.js
+++ b/dist/system/google-maps.js
@@ -182,7 +182,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
 
                     var markerLatLng = new google.maps.LatLng(parseFloat(marker.latitude), parseFloat(marker.longitude));
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         _this2.createMarker({
                             map: _this2.map,
                             position: markerLatLng
@@ -228,7 +228,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                 GoogleMaps.prototype.geocodeAddress = function geocodeAddress(address, geocoder) {
                     var _this3 = this;
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         geocoder.geocode({ 'address': address }, function (results, status) {
                             if (status === google.maps.GeocoderStatus.OK) {
                                 _this3.setCenter(results[0].geometry.location);
@@ -313,7 +313,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                 GoogleMaps.prototype.getCenter = function getCenter() {
                     var _this5 = this;
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         return Promise.resolve(_this5.map.getCenter());
                     });
                 };
@@ -338,7 +338,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                 GoogleMaps.prototype.addressChanged = function addressChanged(newValue) {
                     var _this8 = this;
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         var geocoder = new google.maps.Geocoder();
 
                         _this8.taskQueue.queueMicroTask(function () {
@@ -350,7 +350,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                 GoogleMaps.prototype.latitudeChanged = function latitudeChanged(newValue) {
                     var _this9 = this;
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         _this9.taskQueue.queueMicroTask(function () {
                             _this9.updateCenter();
                         });
@@ -360,7 +360,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                 GoogleMaps.prototype.longitudeChanged = function longitudeChanged(newValue) {
                     var _this10 = this;
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         _this10.taskQueue.queueMicroTask(function () {
                             _this10.updateCenter();
                         });
@@ -370,7 +370,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                 GoogleMaps.prototype.zoomChanged = function zoomChanged(newValue) {
                     var _this11 = this;
 
-                    this._scriptPromise.then(function () {
+                    this._mapPromise.then(function () {
                         _this11.taskQueue.queueMicroTask(function () {
                             var zoomValue = parseInt(newValue, 10);
                             _this11.map.setZoom(zoomValue);

--- a/src/google-maps.js
+++ b/src/google-maps.js
@@ -126,7 +126,7 @@ export class GoogleMaps {
     renderMarker(marker) {
         let markerLatLng = new google.maps.LatLng(parseFloat(marker.latitude), parseFloat(marker.longitude));
 
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             // Create the marker
             this.createMarker({
                 map: this.map,
@@ -184,7 +184,7 @@ export class GoogleMaps {
      *
      */
     geocodeAddress(address, geocoder) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             geocoder.geocode({'address': address}, (results, status) => {
                 if (status === google.maps.GeocoderStatus.OK) {
                     this.setCenter(results[0].geometry.location);
@@ -271,7 +271,7 @@ export class GoogleMaps {
     }
 
     getCenter() {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             return Promise.resolve(this.map.getCenter());
         });
     }
@@ -290,7 +290,7 @@ export class GoogleMaps {
     }
 
     addressChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             let geocoder = new google.maps.Geocoder;
 
             this.taskQueue.queueMicroTask(() => {
@@ -300,7 +300,7 @@ export class GoogleMaps {
     }
 
     latitudeChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 this.updateCenter();
             });
@@ -308,7 +308,7 @@ export class GoogleMaps {
     }
 
     longitudeChanged(newValue) {
-        this._scriptPromise.then(() => {
+        this._mapPromise.then(() => {
             this.taskQueue.queueMicroTask(() => {
                 this.updateCenter();
             });
@@ -316,12 +316,12 @@ export class GoogleMaps {
     }
 
     zoomChanged(newValue) {
-        this._scriptPromise.then(() => {
-            this.taskQueue.queueMicroTask(() => {
-                let zoomValue = parseInt(newValue, 10);
-                this.map.setZoom(zoomValue);
+        this._mapPromise.then(() => {
+                this.taskQueue.queueMicroTask(() => {
+                    let zoomValue = parseInt(newValue, 10);
+                    this.map.setZoom(zoomValue);
+                });
             });
-        });
     }
 
     /**


### PR DESCRIPTION
Missed a few places where scriptPromise was used but it was accessing the map.

If you navigated away to a different page and returned, the script promise would resolve immediately but map would be unavailable.
