### PR TITLE
fix(markers): fix #21 duplicated markers, float err

### DIFF
--- a/dist/amd/google-maps.js
+++ b/dist/amd/google-maps.js
@@ -492,7 +492,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating', 'aureli
                             if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
                                 var renderedMarker = this._renderedMarkers[markerIndex];
 
-                                if (renderedMarker.position.lat() === removedObj.latitude && renderedMarker.position.lng() === removedObj.longitude) {
+                                if (renderedMarker.position.lat().toFixed(12) === removedObj.latitude.toFixed(12) && renderedMarker.position.lng().toFixed(12) === removedObj.longitude.toFixed(12)) {
                                     renderedMarker.setMap(null);
 
                                     this._renderedMarkers.splice(markerIndex, 1);

--- a/dist/aurelia-google-maps.js
+++ b/dist/aurelia-google-maps.js
@@ -443,9 +443,9 @@ export class GoogleMaps {
                         if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
                             let renderedMarker = this._renderedMarkers[markerIndex];
 
-                            // Check if the latitude/longitude matches
-                            if (renderedMarker.position.lat() === removedObj.latitude &&
-                                renderedMarker.position.lng() === removedObj.longitude) {
+                            // Check if the latitude/longitude matches - cast to string of float precision (1e-12)
+                            if (renderedMarker.position.lat().toFixed(12) === removedObj.latitude.toFixed(12) &&
+                                renderedMarker.position.lng().toFixed(12) === removedObj.longitude.toFixed(12)) {
                                 // Set the map to null;
                                 renderedMarker.setMap(null);
 

--- a/dist/commonjs/google-maps.js
+++ b/dist/commonjs/google-maps.js
@@ -495,7 +495,7 @@ var GoogleMaps = exports.GoogleMaps = (_dec = (0, _aureliaTemplating.customEleme
                         if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
                             var renderedMarker = this._renderedMarkers[markerIndex];
 
-                            if (renderedMarker.position.lat() === removedObj.latitude && renderedMarker.position.lng() === removedObj.longitude) {
+                            if (renderedMarker.position.lat().toFixed(12) === removedObj.latitude.toFixed(12) && renderedMarker.position.lng().toFixed(12) === removedObj.longitude.toFixed(12)) {
                                 renderedMarker.setMap(null);
 
                                 this._renderedMarkers.splice(markerIndex, 1);

--- a/dist/es2015/google-maps.js
+++ b/dist/es2015/google-maps.js
@@ -393,7 +393,7 @@ export let GoogleMaps = (_dec = customElement('google-map'), _dec2 = inject(Elem
                         if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
                             let renderedMarker = this._renderedMarkers[markerIndex];
 
-                            if (renderedMarker.position.lat() === removedObj.latitude && renderedMarker.position.lng() === removedObj.longitude) {
+                            if (renderedMarker.position.lat().toFixed(12) === removedObj.latitude.toFixed(12) && renderedMarker.position.lng().toFixed(12) === removedObj.longitude.toFixed(12)) {
                                 renderedMarker.setMap(null);
 
                                 this._renderedMarkers.splice(markerIndex, 1);

--- a/dist/system/configure.js
+++ b/dist/system/configure.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register([], function (_export, _context) {
+    "use strict";
+
     var Configure;
 
     function _classCallCheck(instance, Constructor) {

--- a/dist/system/google-maps.js
+++ b/dist/system/google-maps.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-task-queue', 'aurelia-framework', 'aurelia-event-aggregator', './configure'], function (_export, _context) {
+    "use strict";
+
     var inject, bindable, customElement, TaskQueue, BindingEngine, EventAggregator, Configure, _typeof, _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, GM, BOUNDSCHANGED, CLICK, MARKERCLICK, MARKERDOUBLECLICK, MARKERMOUSEOVER, MARKERMOUSEOUT, APILOADED, GoogleMaps;
 
     function _initDefineProp(target, property, descriptor, context) {
@@ -502,7 +504,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating', 'aurelia-
                                     if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
                                         var renderedMarker = this._renderedMarkers[markerIndex];
 
-                                        if (renderedMarker.position.lat() === removedObj.latitude && renderedMarker.position.lng() === removedObj.longitude) {
+                                        if (renderedMarker.position.lat().toFixed(12) === removedObj.latitude.toFixed(12) && renderedMarker.position.lng().toFixed(12) === removedObj.longitude.toFixed(12)) {
                                             renderedMarker.setMap(null);
 
                                             this._renderedMarkers.splice(markerIndex, 1);

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['./configure'], function (_export, _context) {
+    "use strict";
+
     var Configure;
     return {
         setters: [function (_configure) {

--- a/src/google-maps.js
+++ b/src/google-maps.js
@@ -421,9 +421,9 @@ export class GoogleMaps {
                         if (this._renderedMarkers.hasOwnProperty(markerIndex)) {
                             let renderedMarker = this._renderedMarkers[markerIndex];
 
-                            // Check if the latitude/longitude matches
-                            if (renderedMarker.position.lat() === removedObj.latitude &&
-                                renderedMarker.position.lng() === removedObj.longitude) {
+                            // Check if the latitude/longitude matches - cast to string of float precision (1e-12)
+                            if (renderedMarker.position.lat().toFixed(12) === removedObj.latitude.toFixed(12) &&
+                                renderedMarker.position.lng().toFixed(12) === removedObj.longitude.toFixed(12)) {
                                 // Set the map to null;
                                 renderedMarker.setMap(null);
 


### PR DESCRIPTION
This fixes #21 - it was simply because I had been comparing floats, which is a nonono. My bad! Cast them to string of max float precision (1e-12) to solve it.

Big note: You'll need to rebuild because this was a branch off at v1.0.9 before the breaking packaging changes.
