### PR TITLE
Basic Google Map Type Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ when these values are changed.
 
 ### Map Type
 
-Set the Google Basic Map Type.  
+Set the Google Basic Map Type.  See docs [docs](https://developers.google.com/maps/documentation/javascript/maptypes#BasicMapTypes)
 
 ##### Supported Constants
 * HYBRID - This map type displays a transparent layer of major streets on satellite images.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ These properties also support working with Aurelia's databinding, so you can
 bind any of the above to variables in your viewmodel and the map updates
 when these values are changed.
 
+### Map Type
+
+Set the Google Basic Map Type.  
+
+#### Supported Constants
+* HYBRID - This map type displays a transparent layer of major streets on satellite images.
+* ROADMAP -	This map type displays a normal street map.
+* SATELLITE -	This map type displays satellite images.
+* TERRAIN	- This map type displays maps with physical features such as terrain and vegetatio
+
+``` html
+<template>
+    <google-map markers.bind="myMarkers" map-type="HYBRID"></google-map>
+</template>
+```
+
 ### Map Click Event
 
 It is possible to catch the map click events as specified by the [Google Maps documentation](https://developers.google.com/maps/documentation/javascript/events#ShapeEvents).

--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ when these values are changed.
 
 Set the Google Basic Map Type.  
 
-#### Supported Constants
+##### Supported Constants
 * HYBRID - This map type displays a transparent layer of major streets on satellite images.
 * ROADMAP -	This map type displays a normal street map.
 * SATELLITE -	This map type displays satellite images.
 * TERRAIN	- This map type displays maps with physical features such as terrain and vegetatio
 
+##### Example
 ``` html
 <template>
     <google-map markers.bind="myMarkers" map-type="HYBRID"></google-map>

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ when these values are changed.
 
 ### Map Type
 
-Set the Google Basic Map Type.  See docs [docs](https://developers.google.com/maps/documentation/javascript/maptypes#BasicMapTypes)
+Set the Google Basic Map Type.  See [docs](https://developers.google.com/maps/documentation/javascript/maptypes#BasicMapTypes)
 
 ##### Supported Constants
 * HYBRID - This map type displays a transparent layer of major streets on satellite images.

--- a/src/google-maps.js
+++ b/src/google-maps.js
@@ -26,6 +26,7 @@ export class GoogleMaps {
     @bindable disableDefaultUI = false;
     @bindable markers = [];
     @bindable autoUpdateBounds = false;
+    @bindable mapType = 'ROADMAP';
 
     map = null;
     _renderedMarkers = [];
@@ -84,11 +85,13 @@ export class GoogleMaps {
 
         this._scriptPromise.then(() => {
             let latLng = new google.maps.LatLng(parseFloat(this.latitude), parseFloat(this.longitude));
+            let mapTypeId = this.getMapTypeId();
 
             let options = {
                 center: latLng,
                 zoom: parseInt(this.zoom, 10),
-                disableDefaultUI: this.disableDefaultUI
+                disableDefaultUI: this.disableDefaultUI,
+                mapTypeId: mapTypeId
             };
 
             this.map = new google.maps.Map(this.element, options);
@@ -474,6 +477,18 @@ export class GoogleMaps {
                 this.map.fitBounds(bounds);
             });
         }
+    }
+
+    getMapTypeId() {
+        if (this.mapType.toUpperCase() === 'HYBRID') {
+            return google.maps.MapTypeId.HYBRID;
+        } else if (this.mapType.toUpperCase() === 'SATELLITE') {
+            return google.maps.MapTypeId.SATELLITE;
+        } else if (this.mapType.toUpperCase() === 'TERRAIN') {
+            return google.maps.MapTypeId.TERRAIN;
+        }
+
+        return google.maps.MapTypeId.ROADMAP;
     }
 
     error() {


### PR DESCRIPTION
This pull requests adds Basic Google Map Type support.  You can set the Google Map type as a configurable parameter in the <google-map> element. 

Documentation: 
https://developers.google.com/maps/documentation/javascript/maptypes#BasicMapTypes
