### PR TITLE
fix(build): fix build/install by using cjs for #27

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "jspm": {
     "registry": "npm",
     "main": "index",
-    "format": "amd",
+    "format": "cjs",
     "directories": {
-      "dist": "dist/amd"
+      "dist": "dist/commonjs"
     },
     "dependencies": {
         "aurelia-binding": "^1.0.1",


### PR DESCRIPTION
Alright so did a bit of digging tonight. Hopefully this can provoke someone to greater enlightenment.

So it seems as if we're not defining a "naked" definition. I have no idea if that's the right word (almost certainly isn't) but what i mean is that we define "index" which never gets executed (https://github.com/Vheissu/aurelia-google-maps/blob/master/dist/amd/index.js#L429)

Because it's never executed, it never defines a `configure` method so the plugin is never started, never defines the custom element, etc.

If you change this line to:
`define(["require", "exports", "configure", "google-maps"], function (require, exports, configure_2, google_maps_1) {`

It works, but it feels sketchy because it's the export file, not the source/build. AMD on the other hand works fine this whole time, so I just changed it to use this at the moment and it seems to work fine.

Ideally, we should fix every export but I have no clue where to start. In the meantime you can install the patched version:

`jspm install aurelia-google-maps=github:tomtomau/aurelia-google-maps@fix-build`
