### PR TITLE
Add resize method to the control

### DIFF
--- a/dist/amd/google-maps.d.ts
+++ b/dist/amd/google-maps.d.ts
@@ -23,7 +23,9 @@ export declare class GoogleMaps {
     _scriptPromise: Promise<any> | any;
     _mapPromise: Promise<any> | any;
     _mapResolve: Promise<any> | any;
+    _locationByAddressMarkers: any;
     constructor(element: Element, taskQueue: TaskQueue, config: Configure, bindingEngine: BindingEngine, eventAggregator: EventAggregator);
+    clearMarkers(): void;
     attached(): void;
     /**
      * Send the map bounds as an EA event
@@ -96,4 +98,5 @@ export declare class GoogleMaps {
     zoomToMarkerBounds(force?: boolean): void;
     getMapTypeId(): any;
     error(): void;
+    resize(): void;
 }

--- a/dist/commonjs/google-maps.d.ts
+++ b/dist/commonjs/google-maps.d.ts
@@ -23,7 +23,9 @@ export declare class GoogleMaps {
     _scriptPromise: Promise<any> | any;
     _mapPromise: Promise<any> | any;
     _mapResolve: Promise<any> | any;
+    _locationByAddressMarkers: any;
     constructor(element: Element, taskQueue: TaskQueue, config: Configure, bindingEngine: BindingEngine, eventAggregator: EventAggregator);
+    clearMarkers(): void;
     attached(): void;
     /**
      * Send the map bounds as an EA event
@@ -96,4 +98,5 @@ export declare class GoogleMaps {
     zoomToMarkerBounds(force?: boolean): void;
     getMapTypeId(): any;
     error(): void;
+    resize(): void;
 }

--- a/dist/commonjs/google-maps.js
+++ b/dist/commonjs/google-maps.js
@@ -21,6 +21,7 @@ var MARKERCLICK = GM + ":marker:click";
 var MARKERMOUSEOVER = GM + ":marker:mouse_over";
 var MARKERMOUSEOUT = GM + ":marker:mouse_out";
 var APILOADED = GM + ":api:loaded";
+var LOCATIONADDED = GM + ":marker:added";
 var GoogleMaps = (function () {
     function GoogleMaps(element, taskQueue, config, bindingEngine, eventAggregator) {
         this.address = null;
@@ -38,6 +39,7 @@ var GoogleMaps = (function () {
         this._scriptPromise = null;
         this._mapPromise = null;
         this._mapResolve = null;
+        this._locationByAddressMarkers = [];
         this.element = element;
         this.taskQueue = taskQueue;
         this.config = config;
@@ -70,7 +72,20 @@ var GoogleMaps = (function () {
             self.map.panTo(self._renderedMarkers[data.index].position);
             self.map.setZoom(17);
         });
+        this.eventAggregator.subscribe("clearMarkers", function () {
+            this.clearMarkers();
+        });
     }
+    GoogleMaps.prototype.clearMarkers = function () {
+        if (!this._locationByAddressMarkers || !this._renderedMarkers) {
+            return;
+        }
+        this._locationByAddressMarkers.concat(this._renderedMarkers).forEach(function (marker) {
+            marker.setMap(null);
+        });
+        this._locationByAddressMarkers = [];
+        this._renderedMarkers = [];
+    };
     GoogleMaps.prototype.attached = function () {
         var _this = this;
         this.element.addEventListener('dragstart', function (evt) {
@@ -218,13 +233,18 @@ var GoogleMaps = (function () {
         var _this = this;
         this._mapPromise.then(function () {
             geocoder.geocode({ 'address': address }, function (results, status) {
-                if (status === window.google.maps.GeocoderStatus.OK) {
-                    _this.setCenter(results[0].geometry.location);
-                    _this.createMarker({
-                        map: _this.map,
-                        position: results[0].geometry.location
-                    });
+                if (status !== window.google.maps.GeocoderStatus.OK) {
+                    return;
                 }
+                var firstResultLocation = results[0].geometry.location;
+                _this.setCenter(firstResultLocation);
+                _this.createMarker({
+                    map: _this.map,
+                    position: firstResultLocation
+                }).then(function (createdMarker) {
+                    _this._locationByAddressMarkers.push(createdMarker);
+                    _this.eventAggregator.publish(LOCATIONADDED, Object.assign(createdMarker, { placeId: results[0].place_id }));
+                });
             });
         });
     };
@@ -472,6 +492,9 @@ var GoogleMaps = (function () {
     };
     GoogleMaps.prototype.error = function () {
         console.error.apply(console, arguments);
+    };
+    GoogleMaps.prototype.resize = function () {
+        window.google.maps.event.trigger(this.map, 'resize');
     };
     return GoogleMaps;
 }());

--- a/dist/es2015/google-maps.d.ts
+++ b/dist/es2015/google-maps.d.ts
@@ -23,7 +23,9 @@ export declare class GoogleMaps {
     _scriptPromise: Promise<any> | any;
     _mapPromise: Promise<any> | any;
     _mapResolve: Promise<any> | any;
+    _locationByAddressMarkers: any;
     constructor(element: Element, taskQueue: TaskQueue, config: Configure, bindingEngine: BindingEngine, eventAggregator: EventAggregator);
+    clearMarkers(): void;
     attached(): void;
     /**
      * Send the map bounds as an EA event
@@ -96,4 +98,5 @@ export declare class GoogleMaps {
     zoomToMarkerBounds(force?: boolean): void;
     getMapTypeId(): any;
     error(): void;
+    resize(): void;
 }

--- a/dist/es2015/google-maps.js
+++ b/dist/es2015/google-maps.js
@@ -20,6 +20,7 @@ var MARKERCLICK = GM + ":marker:click";
 var MARKERMOUSEOVER = GM + ":marker:mouse_over";
 var MARKERMOUSEOUT = GM + ":marker:mouse_out";
 var APILOADED = GM + ":api:loaded";
+var LOCATIONADDED = GM + ":marker:added";
 var GoogleMaps = (function () {
     function GoogleMaps(element, taskQueue, config, bindingEngine, eventAggregator) {
         this.address = null;
@@ -37,6 +38,7 @@ var GoogleMaps = (function () {
         this._scriptPromise = null;
         this._mapPromise = null;
         this._mapResolve = null;
+        this._locationByAddressMarkers = [];
         this.element = element;
         this.taskQueue = taskQueue;
         this.config = config;
@@ -69,7 +71,20 @@ var GoogleMaps = (function () {
             self.map.panTo(self._renderedMarkers[data.index].position);
             self.map.setZoom(17);
         });
+        this.eventAggregator.subscribe("clearMarkers", function () {
+            this.clearMarkers();
+        });
     }
+    GoogleMaps.prototype.clearMarkers = function () {
+        if (!this._locationByAddressMarkers || !this._renderedMarkers) {
+            return;
+        }
+        this._locationByAddressMarkers.concat(this._renderedMarkers).forEach(function (marker) {
+            marker.setMap(null);
+        });
+        this._locationByAddressMarkers = [];
+        this._renderedMarkers = [];
+    };
     GoogleMaps.prototype.attached = function () {
         var _this = this;
         this.element.addEventListener('dragstart', function (evt) {
@@ -217,13 +232,18 @@ var GoogleMaps = (function () {
         var _this = this;
         this._mapPromise.then(function () {
             geocoder.geocode({ 'address': address }, function (results, status) {
-                if (status === window.google.maps.GeocoderStatus.OK) {
-                    _this.setCenter(results[0].geometry.location);
-                    _this.createMarker({
-                        map: _this.map,
-                        position: results[0].geometry.location
-                    });
+                if (status !== window.google.maps.GeocoderStatus.OK) {
+                    return;
                 }
+                var firstResultLocation = results[0].geometry.location;
+                _this.setCenter(firstResultLocation);
+                _this.createMarker({
+                    map: _this.map,
+                    position: firstResultLocation
+                }).then(function (createdMarker) {
+                    _this._locationByAddressMarkers.push(createdMarker);
+                    _this.eventAggregator.publish(LOCATIONADDED, Object.assign(createdMarker, { placeId: results[0].place_id }));
+                });
             });
         });
     };
@@ -471,6 +491,9 @@ var GoogleMaps = (function () {
     };
     GoogleMaps.prototype.error = function () {
         console.error.apply(console, arguments);
+    };
+    GoogleMaps.prototype.resize = function () {
+        window.google.maps.event.trigger(this.map, 'resize');
     };
     return GoogleMaps;
 }());

--- a/dist/system/google-maps.d.ts
+++ b/dist/system/google-maps.d.ts
@@ -23,7 +23,9 @@ export declare class GoogleMaps {
     _scriptPromise: Promise<any> | any;
     _mapPromise: Promise<any> | any;
     _mapResolve: Promise<any> | any;
+    _locationByAddressMarkers: any;
     constructor(element: Element, taskQueue: TaskQueue, config: Configure, bindingEngine: BindingEngine, eventAggregator: EventAggregator);
+    clearMarkers(): void;
     attached(): void;
     /**
      * Send the map bounds as an EA event
@@ -96,4 +98,5 @@ export declare class GoogleMaps {
     zoomToMarkerBounds(force?: boolean): void;
     getMapTypeId(): any;
     error(): void;
+    resize(): void;
 }

--- a/src/google-maps.ts
+++ b/src/google-maps.ts
@@ -552,4 +552,8 @@ export class GoogleMaps {
     error() {
         console.error.apply(console, arguments);
     }
+
+    resize() {
+        (<any>window).google.maps.event.trigger(this.map, 'resize');
+    }
 }


### PR DESCRIPTION
This adds a resize method to the control whose implementation simply triggers the resize event on the underlying map control which allows for more dynamic layout situations where the map control does not know its size during initial UI rendering.

Fixes #43.