### PR TITLE
Fix bug where resize being called before map has fully loaded results in an error

### DIFF
--- a/src/google-maps.ts
+++ b/src/google-maps.ts
@@ -559,6 +559,10 @@ export class GoogleMaps {
     }
 
     resize() {
-        (<any>window).google.maps.event.trigger(this.map, 'resize');
+        this._mapPromise.then(() => {
+            this.taskQueue.queueMicroTask(() => {
+                (<any>window).google.maps.event.trigger(this.map, 'resize');
+            });
+        });
     }
 }


### PR DESCRIPTION
This addresses issue #48 that I raised by ensuring that `_mapPromise` has completed before attempting to interact with the map to actually resize it.