### PR TITLE
Added the possibility of creating a draggable marker

### DIFF
--- a/src/google-maps.ts
+++ b/src/google-maps.ts
@@ -235,6 +235,10 @@ export class GoogleMaps {
                     createdMarker.setTitle(marker.title);
                 }
 
+                if (marker.draggable) {
+                    createdMarker.setDraggable(marker.draggable);
+                }
+
                 if (marker.infoWindow) {
                     createdMarker.infoWindow = new (<any>window).google.maps.InfoWindow({
                         content: marker.infoWindow.content,


### PR DESCRIPTION
I needed to create a **draggable marker**, and couldn't find a way to create one using your plugin, so I've added the property **draggable** to the marker to make this possible.

With the _marker:mouse_out_ event it's possible to get the new marker position.