### PR TITLE
Google Maps API v3: Using setZoom after fitBounds

### DIFF
--- a/src/google-maps.ts
+++ b/src/google-maps.ts
@@ -543,6 +543,11 @@ export class GoogleMaps {
             }
 
             this.map.fitBounds(bounds);
+            let listener = google.maps.event.addListener(this.map, "idle", function() {
+                if (this.map.getZoom() > this.zoom) 
+                    this.map.setZoom(this.zoom);
+                google.maps.event.removeListener(listener);
+            });
         });
     }
 


### PR DESCRIPTION
setZoom after fitBounds because zoom property not working on initial map.

Just wanted to add that it further by using the addListenerOnce method... that way, we don't have to save the listener and manually remove it, as the method will take care of that.