### PR TITLE
fix(config-error): correct error trigger

### DIFF
--- a/src/google-maps.ts
+++ b/src/google-maps.ts
@@ -82,7 +82,7 @@ export class GoogleMaps {
             logger.error('No API script is defined.');
         }
 
-        if ((!config.get('apiKey') && config.get('apiKey') !== false) || (!config.get('clientId') && config.get('clientId') !== false)) {
+        if ((!config.get('apiKey') && config.get('apiKey') !== false) && (!config.get('clientId') && config.get('clientId') !== false)) {
             logger.error('No API key or client ID has been specified.');
         }
 


### PR DESCRIPTION
Throw error only on missing _all_ credentials.

Fixes #99